### PR TITLE
Force delete to prevent hanging

### DIFF
--- a/podsuper-nodecleanup.sh
+++ b/podsuper-nodecleanup.sh
@@ -15,6 +15,6 @@ do
     if [[ "$namespace" == "openshift-dns" ]]; then
             echo "Cleaning up  $nodename/$namespace/$podname"
             ./bin/sendalert.sh NODENOTREADY "PodSupervisor: Node: $nodename Application: $namespace Pod: $podname - Deleted"
-            oc delete po/$podname --namespace $namespace
+            oc delete po/$podname --namespace $namespace --force
         fi
 done < "$input"


### PR DESCRIPTION
In our lab, I stopped the processes:
```
   $ ssh core@openshift-worker-2 'sudo systemctl stop crio'
   $ ssh core@openshift-worker-2 'sudo systemctl stop kubelet'
```

Confirmed node state:
```
   $ oc get nodes openshift-worker-2 -o wide 
   NAME                 STATUS     ROLES               AGE   VERSION            INTERNAL-IP       EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                 CONTAINER-RUNTIME
   openshift-worker-2   NotReady   worker,workerperf   23h   v1.20.15+98b2293   192.168.123.222   <none>        Red Hat Enterprise Linux CoreOS 47.84.202206302254-0 (Ootpa)   4.18.0-305.49.1.el8_4.x86_64   cri-o://Unknown
```

Executed the script and can see the pod cleaned up:
```
   $ bash podsupervisor.sh 
   /root/podsupervisor
   root
   /root
   Cleaning up openshift-worker-2
   Cleaning up  openshift-worker-2/openshift-dns/dns-default-zzf79
   pod "dns-default-zzf79" deleted
   
   $ oc get pods -n openshift-dns -o wide
   NAME                READY   STATUS        RESTARTS   AGE   IP            NODE                 NOMINATED NODE   READINESS GATES
   dns-default-gsx5g   3/3     Running       0          20m   172.25.0.16   openshift-master-0   <none>           <none>
   dns-default-kvwwx   3/3     Running       0          20m   172.27.0.5    openshift-worker-1   <none>           <none>
   dns-default-mjdxf   3/3     Running       0          20m   172.24.0.52   openshift-master-1   <none>           <none>
   dns-default-nf642   3/3     Running       0          20m   172.26.0.7    openshift-master-2   <none>           <none>
   dns-default-qpvwf   3/3     Running       0          20m   172.24.2.71   openshift-worker-0   <none>           <none>
   dns-default-zzf79   3/3     Terminating   0          20m   172.24.4.8    openshift-worker-2
```

I then disabled another node and validated :
```
   $ ssh core@openshift-worker-1 'sudo systemctl stop crio'
   $ ssh core@openshift-worker-1 'sudo systemctl stop kubelet'
   
   $ oc get nodes openshift-worker-1 openshift-worker-2 -o wide 
   NAME                 STATUS     ROLES               AGE   VERSION            INTERNAL-IP       EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                 CONTAINER-RUNTIME
   openshift-worker-1   NotReady   worker,workerperf   10d   v1.20.15+98b2293   192.168.123.221   <none>        Red Hat Enterprise Linux CoreOS 47.84.202206302254-0 (Ootpa)   4.18.0-305.49.1.el8_4.x86_64   cri-o://Unknown
   openshift-worker-2   NotReady   worker,workerperf   23h   v1.20.15+98b2293   192.168.123.222   <none>        Red Hat Enterprise Linux CoreOS 47.84.202206302254-0 (Ootpa)   4.18.0-305.49.1.el8_4.x86_64   cri-o://Unknown
```

but a re-run of the script produced the same exact result as previously. The reason this wasn't progressing to all workers is because the 'podsupervisor.sh' finds NotReady workers and then attempts to serial delete the pods on them based on the code in 'podsuper-nodecleanup.sh'. However, the pod gets stuck in 'Terminating' so the 'oc delete pod' gets hung:
```
   $ vi podsupervisor.sh
               ./podsuper-nodecleanup.sh $nodename
   
   $ vi podsuper-nodecleanup.sh
               oc delete po/$podname --namespace $namespace
```

All I did was add a '--force' so it would delete the pod from the ETCD database instead of hanging around waiting for it to get reaped
```
   $ vi podsuper-nodecleanup.sh
               oc delete po/$podname --namespace $namespace --force
```

After doing so, we can see this working as expected:
```
   [root@openshift-jumpserver-0 podsupervisor]# bash podsupervisor.sh 
   /root/podsupervisor
   root
   /root
   Cleaning up openshift-worker-1
   Cleaning up  openshift-worker-1/openshift-dns/dns-default-t6h29
   warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
   pod "dns-default-t6h29" force deleted
   Cleaning up openshift-worker-2
   Cleaning up  openshift-worker-2/openshift-dns/dns-default-zzf79
   warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
   pod "dns-default-zzf79" force deleted
```